### PR TITLE
Use stripLineEnd in MainTest，avoid test fail in windows.

### DIFF
--- a/src/test/scala/nz/daved/inline_macros/MainTest.scala
+++ b/src/test/scala/nz/daved/inline_macros/MainTest.scala
@@ -11,6 +11,6 @@ class MainTest extends FlatSpec with Matchers {
     Console.withOut(new PrintStream(out)) {
       Test.main(Array())
     }
-    out.toString shouldBe "hello world\n"
+    out.toString.stripLineEnd shouldBe "hello world"
   }
 }


### PR DESCRIPTION
test failed in windows because of lineend.
